### PR TITLE
destDir: default "/", accept string, tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,17 @@ Flatten.prototype = Object.create(Writer.prototype);
 Flatten.prototype.constructor = Flatten;
 function Flatten (inputTree, options) {
   if (!(this instanceof Flatten)) return new Flatten(inputTree, options);
+  
+  if(typeof options === 'string'){
+    options = { destDir: options };
+  } 
+  else {
+    options = options || {};
+    options.destDir = options.destDir || '/';
+  }
+
   this.inputTree = inputTree;
-  this.options = options || {};
+  this.options = options;
 };
 
 Flatten.prototype.write = function (readTree, destDir) {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+var flatten = require('./index'),
+	assert = require('assert'),
+	inputTree;
+
+assert(flatten(inputTree).options.destDir==='/', 
+	'destDir defaults to "/"');
+
+assert(flatten(inputTree, '/mydir').options.destDir==='/mydir', 
+	'string destDir converted to options');
+
+console.log('pass');


### PR DESCRIPTION
Should be able to write

``` js
catalog = concat( flatten(postPages), {...
```

instead of:

``` js
catalog = concat( flatten(postPages, { destDir: '/' }), {...
```

Also, `destDir` is your only option param, so should be able to write:

``` js
var vendor = from('vendor'),
    vendorCss = flatten( vendor('.css'), '/css' )
```

as shorthand for:

``` js
var vendor = from('vendor'),
    vendorCss = flatten( vendor('.css'), { destDir: '/css' } )
```

I don't like submitting PR w/o tests and you didn't have any choosen test fw, so I put in simple test file.
