### PR TITLE
Fix issue where plugin fails if directory has a `.`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
-var path = require('path')
-var helpers = require('broccoli-kitchen-sink-helpers')
-var Writer = require('broccoli-writer');
+var path     = require('path');
+var helpers  = require('broccoli-kitchen-sink-helpers');
+var Writer   = require('broccoli-writer');
+var walkSync = require('walk-sync')
 
 module.exports = Flatten;
 Flatten.prototype = Object.create(Writer.prototype);
 Flatten.prototype.constructor = Flatten;
 function Flatten (inputTree, options) {
   if (!(this instanceof Flatten)) return new Flatten(inputTree, options);
-  
+
   if(typeof options === 'string'){
     options = { destDir: options };
-  } 
+  }
   else {
     options = options || {};
     options.destDir = options.destDir || '/';
@@ -24,19 +25,16 @@ Flatten.prototype.write = function (readTree, destDir) {
   var self = this
 
   return readTree(this.inputTree).then(function (srcDir) {
-    var baseDir = path.join(srcDir)
-    var files = helpers.multiGlob(['**/*.*'], {
-      cwd: baseDir,
-      root: baseDir,
-      expand: true,
-      nomount: false
-    })
 
-    for (var i = 0; i < files.length; i++) {
-      helpers.copyRecursivelySync(
-        path.join(srcDir, files[i]),
-        path.join(destDir, self.options.destDir, path.basename(files[i]))
-      )
+    var filePaths = walkSync(srcDir);
+    for (var i = 0; i < filePaths.length; i++) {
+      var filePath = filePaths[i];
+      if (!(filePath.slice(-1) === '/')) {
+        helpers.copyRecursivelySync(
+          path.join(srcDir, filePath),
+          path.join(destDir, self.options.destDir, path.basename(filePath))
+        )
+      }
     }
 
   })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.0",
     "broccoli-writer": "^0.1.1",
-    "path": "^0.4.9"
+    "path": "^0.4.9",
+    "walk-sync": "^0.1.2"
   }
 }


### PR DESCRIPTION
Looks like the method for determining whether or not something is a file is if it matches the pattern `'**/*.*'`.  Unfortunately, directories that have a `.` in them also match this pattern, as I noticed on a project I was working on. The specific example I saw where this was failing was on:

```
bower_components/accounting.js/accounting.js
```

I believe the included method will be more robust. the `walk-sync` library guarantees that all directories will end in a `/`. This is the method [used in broccoli-filter](https://github.com/broccolijs/broccoli-filter/blob/master/index.js#L36) for instance.
